### PR TITLE
 Generate all points and create a no-noise option

### DIFF
--- a/ouster_gazebo_plugins/src/GazeboRosOusterLaser.cpp
+++ b/ouster_gazebo_plugins/src/GazeboRosOusterLaser.cpp
@@ -159,6 +159,8 @@ void GazeboRosOusterLaser::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf
         gaussian_noise_ = _sdf->GetElement("gaussianNoise")->Get<double>();
         if(gaussian_noise_ == 0.0) // shouldn't it be compared to epsilon ?
             ROS_INFO("Ouster laser plugin : gaussian Noise set to 0, using noise generation based on datasheet");
+        else if(gaussian_noise_ == -1.0)
+            ROS_INFO("Ouster laser plugin : gaussian Noise unset");
         else
             ROS_INFO("Ouster laser plugin : gaussian Noise set to %f", gaussian_noise_);
     }
@@ -312,7 +314,7 @@ void GazeboRosOusterLaser::OnScan(ConstLaserScanStampedPtr& _msg){
             if (gaussian_noise_ != 0.0){ // shouldn't it be compared to epsilon ?
                 r += gaussianKernel(0, gaussian_noise_);
             }
-            else {
+            else if (gaussian_noise_ != -1.0){
                 // Noise set by the datasheet
                 double g_noise = gaussianKernel(0, 1.);
                 if(r <= 2.){

--- a/ouster_gazebo_plugins/src/GazeboRosOusterLaser.cpp
+++ b/ouster_gazebo_plugins/src/GazeboRosOusterLaser.cpp
@@ -311,7 +311,7 @@ void GazeboRosOusterLaser::OnScan(ConstLaserScanStampedPtr& _msg){
             }
 
             // Noise
-            if (gaussian_noise_ != 0.0){ // shouldn't it be compared to epsilon ?
+            if (gaussian_noise_ > 0.0){ // shouldn't it be compared to epsilon ?
                 r += gaussianKernel(0, gaussian_noise_);
             }
             else if (gaussian_noise_ != -1.0){


### PR DESCRIPTION
The plugins is modified to provides all points (useful to keep the point clouds organised, done on the real LiDAR) and propose a no-noise simulation (by putting noise parameter to -1).
The simulation has been checked on GPU and CPU versions for each new cases.

PS:
 - the real LiDAR gives NaN and 0 points but the difference is for now unknown. The plugin simply provides 0 points.
 - this merge request will be useful for @Guitheg.